### PR TITLE
refactor: update user deletion logic to use IDs instead of full objects in users_bloc.dart

### DIFF
--- a/lib/src/features/users/domain/usecases/delete_users_usecase.dart
+++ b/lib/src/features/users/domain/usecases/delete_users_usecase.dart
@@ -7,9 +7,29 @@ class DeleteUsersUseCase {
 
   final IUsersRepository _repository;
 
-  Future<void> call(List<User> users) async {
+  Future<({List<User> updated, List<User> deleted})> call({
+    required List<UserID> ids,
+    required List<User> currentUsers,
+  }) async {
+
+    // 1. Делаем запрос на удаление по id
     await Future.wait(
-      users.map((user) => _repository.deleteUser(DeleteUserParams(user.uuid))),
+      ids.map((id) => _repository.deleteUser(DeleteUserParams(id))),
     );
+
+    // 2. Локально фильтруем список и возвращаем новый
+    final idSet = ids.toSet();
+
+    final updatedUsers = <User>[];
+    final deletedUsers = <User>[];
+
+    for (final user in currentUsers) {
+      if (idSet.contains(user.uuid)) {
+        deletedUsers.add(user);
+      } else {
+        updatedUsers.add(user);
+      }
+    }
+    return (updated: updatedUsers, deleted: deletedUsers);
   }
 }

--- a/lib/src/features/users/presentation/blocs/users_bloc/users_event.dart
+++ b/lib/src/features/users/presentation/blocs/users_bloc/users_event.dart
@@ -3,7 +3,10 @@ part of 'users_bloc.dart';
 sealed class UsersEvent {
   factory UsersEvent.getUsers() = _GetUsers;
 
-  factory UsersEvent.deleteUsers(List<User> users) = _DeleteUsers;
+  factory UsersEvent.deleteUsers(List<User> users) {
+    final ids = users.map((it) => it.uuid).toList();
+    return _DeleteUsers(ids);
+  }
 
   factory UsersEvent.forceConfirmEmails(List<User> users) = _ForceConfirmEmails;
 }
@@ -11,9 +14,9 @@ sealed class UsersEvent {
 final class _GetUsers implements UsersEvent {}
 
 final class _DeleteUsers implements UsersEvent {
-  _DeleteUsers(this.users);
+  _DeleteUsers(this.ids);
 
-  final List<User> users;
+  final List<UserID> ids;
 }
 
 final class _ForceConfirmEmails implements UsersEvent {

--- a/lib/src/features/users/presentation/pages/user_list_page/widgets/users_actions_popup_menu_button.dart
+++ b/lib/src/features/users/presentation/pages/user_list_page/widgets/users_actions_popup_menu_button.dart
@@ -3,8 +3,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:genesis/src/core/extensions/localized_build_context.dart';
 import 'package:genesis/src/features/users/domain/entities/user.dart';
 import 'package:genesis/src/features/users/presentation/blocs/users_bloc/users_bloc.dart';
-import 'package:genesis/src/shared/presentation/ui/widgets/delete_users_dialog.dart';
 import 'package:genesis/src/shared/presentation/ui/tokens/palette.dart';
+import 'package:genesis/src/shared/presentation/ui/widgets/delete_users_dialog.dart';
 
 class UsersActionsPopupMenuButton extends StatelessWidget {
   const UsersActionsPopupMenuButton({required this.user, super.key});


### PR DESCRIPTION
This commit refactors the user deletion functionality. The `DeleteUsers` event and use case now operate on a list of user IDs (`List<UserID>`) instead of a list of `User` objects.

This change simplifies the event creation and moves the logic for filtering the user list after deletion into the `DeleteUsersUseCase`, improving separation of concerns and making the `UsersBloc` cleaner.